### PR TITLE
WIP: Attempt to automate installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 dist
+extern

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,14 @@ endif()
 
 find_package(Torch REQUIRED)
 
+set(INSTALL_RPATH "@loader_path")
+set(CMAKE_BUILD_WITH_INSTALL_RPATH 1)
+
 include_directories(${CMAKE_JS_INC})
 file(GLOB SOURCE_FILES "src/*.cc" "src/*.h")
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
+set_property(TARGET ${PROJECT_NAME} PROPERTY INSTALL_RPATH  "@loader_path")
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/node_modules/node-addon-api")
 target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,13 @@ if (NOT MSVC)
   set(CMAKE_C_STANDARD 11)
 endif()
 
-find_package(Torch REQUIRED)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # Without this set, the package is only found by absolute path, so you can't move it on disk
+  set(INSTALL_RPATH "@loader_path")
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH 1)
+endif()
 
-set(INSTALL_RPATH "@loader_path")
-set(CMAKE_BUILD_WITH_INSTALL_RPATH 1)
+find_package(Torch REQUIRED)
 
 include_directories(${CMAKE_JS_INC})
 file(GLOB SOURCE_FILES "src/*.cc" "src/*.h")

--- a/fetch-native-deps.sh
+++ b/fetch-native-deps.sh
@@ -1,0 +1,21 @@
+#/bin/bash
+
+EXTERN_DIR=extern
+
+LIBTORCH_DIR=$EXTERN_DIR/libtorch/
+
+# macOS url. TODO: detect platform and install correct prebuilt lib
+TORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-macos-latest.zip
+#TORCH_URL=https://download.pytorch.org/libtorch/nightly/cu100/libtorch-shared-with-deps-latest.zip
+
+
+if [ ! -d "${LIBTORCH_DIR}" ]; then
+  echo "Downloading libtorch to ${LIBTORCH_DIR}..."
+  mkdir -p ${LIBTORCH_DIR}
+
+  curl -o libtorch.zip ${TORCH_URL}
+  unzip libtorch.zip -d ${EXTERN_DIR}
+  rm -f libtorch.zip
+else
+  echo "libtorch already installed in ${LIBTORCH_DIR}"
+fi

--- a/fetch-native-deps.sh
+++ b/fetch-native-deps.sh
@@ -1,20 +1,48 @@
 #/bin/bash
 
 EXTERN_DIR=extern
-
 LIBTORCH_DIR=$EXTERN_DIR/libtorch/
 
-# macOS url. TODO: detect platform and install correct prebuilt lib
-TORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-macos-latest.zip
-#TORCH_URL=https://download.pytorch.org/libtorch/nightly/cu100/libtorch-shared-with-deps-latest.zip
-
+# Detect OS via https://stackoverflow.com/a/8597411
+# URLs are from https://pytorch.org/get-started/locally/
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  # Detect whether CUDA is installed
+  if [[ -z $CUDA_ROOT ]] && [[ -d "$CUDA_ROOT" ]]; then
+    if [[ "$CUDA_VERSION" == "10"* ]]; then
+      LIBTORCH_URL=https://download.pytorch.org/libtorch/nightly/cu100/libtorch-shared-with-deps-latest.zip
+    elif [[ "$CUDA_VERSION" == "9"* ]]; then
+      LIBTORCH_URL=https://download.pytorch.org/libtorch/cu90/libtorch-shared-with-deps-latest.zip
+    fi
+  else
+    LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-latest.zip
+  fi
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  # Mac OSX doesn't support CUDA anymore
+  LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-macos-latest.zip
+elif [[ "$OSTYPE" == "cygwin" ]]; then
+  # TODO
+  # POSIX compatibility layer and Linux environment emulation for Windows
+  LIBTORCH_URL=""
+elif [[ "$OSTYPE" == "msys" ]]; then
+  # Lightweight shell and GNU utilities compiled for Windows (part of MinGW)
+  LIBTORCH_URL=""
+elif [[ "$OSTYPE" == "win32" ]]; then
+  # I'm not sure this can happen.
+  echo "win32 currently unsupported"
+elif [[ "$OSTYPE" == "freebsd"* ]]; then
+  echo "FreeBSD currently unsupported"
+else
+  # Unknown.
+  echo "Unknown platform. Need to build LibTorch from source."
+fi
 
 if [ ! -d "${LIBTORCH_DIR}" ]; then
   echo "Downloading libtorch to ${LIBTORCH_DIR}..."
   mkdir -p ${LIBTORCH_DIR}
 
-  curl -o libtorch.zip ${TORCH_URL}
-  unzip libtorch.zip -d ${EXTERN_DIR}
+  curl -o libtorch.zip ${LIBTORCH_URL}
+  echo "Extracting libtorch to ${LIBTORCH_DIR}..."
+  unzip -q libtorch.zip -d ${EXTERN_DIR}
   rm -f libtorch.zip
 else
   echo "libtorch already installed in ${LIBTORCH_DIR}"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "author": "Kittipat Virochsiri",
   "license": "MIT",
   "scripts": {
-    "preinstall": "yarn fetch-deps && yarn compile && yarn build",
+    "preinstall": "yarn fetch-deps && yarn compile && yarn copy-libs && yarn build",
     "build": "rm -rf dist/ && tsc && cp lib/torch.* dist/",
-    "fetch-deps": "./fetch_native_deps.sh",
+    "fetch-deps": "scripts/fetch-native-deps.sh",
+    "copy-libs": "scripts/copy-libs.sh",
     "compile": "cmake-js compile --CDCMAKE_PREFIX_PATH=./extern/libtorch",
     "rebuild": "cmake-js rebuild --CDCMAKE_PREFIX_PATH=./extern/libtorch"
   },

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "author": "Kittipat Virochsiri",
   "license": "MIT",
   "scripts": {
-    "install": "yarn compile && yarn build",
+    "preinstall": "yarn fetch-deps && yarn compile && yarn build",
     "build": "rm -rf dist/ && tsc && cp lib/torch.* dist/",
-    "compile": "cmake-js compile --CDCMAKE_PREFIX_PATH=../libtorch",
-    "rebuild": "cmake-js rebuild --CDCMAKE_PREFIX_PATH=../libtorch"
+    "fetch-deps": "./fetch_native_deps.sh",
+    "compile": "cmake-js compile --CDCMAKE_PREFIX_PATH=./extern/libtorch",
+    "rebuild": "cmake-js rebuild --CDCMAKE_PREFIX_PATH=./extern/libtorch"
   },
   "devDependencies": {
     "cmake-js": "^4.0.1",

--- a/scripts/copy-libs.sh
+++ b/scripts/copy-libs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Version for distribution?
+#mkdir -p dist/native/
+#cp build/Release/torch-js.node dist/native
+#cp extern/libtorch/lib dist/native
+
+EXTERN_DIR=extern
+LIBTORCH_DIR=$EXTERN_DIR/libtorch/
+MKLML_DIR=$EXTERN_DIR/mklml/
+BUILT_PRODUCTS_DIR=build/Release
+
+echo "Copying prebuilt libraries to ${BUILT_PRODUCTS_DIR}"
+cp -a $LIBTORCH_DIR/lib/. $BUILT_PRODUCTS_DIR
+cp -a $MKLML_DIR/lib/. $BUILT_PRODUCTS_DIR

--- a/scripts/copy-libs.sh
+++ b/scripts/copy-libs.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-# Version for distribution?
-#mkdir -p dist/native/
-#cp build/Release/torch-js.node dist/native
-#cp extern/libtorch/lib dist/native
+# TODO: Only copy necessary files for distribution
 
 EXTERN_DIR=extern
 LIBTORCH_DIR=$EXTERN_DIR/libtorch/

--- a/scripts/fetch-native-deps.sh
+++ b/scripts/fetch-native-deps.sh
@@ -1,11 +1,20 @@
 #/bin/bash
 
+# This script attempts to install the following dependencies as prebuilt libs
+#   - libtorch (C++ library version of PyTorch)
+#   - libmklml (https://github.com/intel/mkl-dnn/)
+# Some platform detection is attempted, but very hacky!
+
 EXTERN_DIR=extern
 LIBTORCH_DIR=$EXTERN_DIR/libtorch/
+MKLML_DIR=$EXTERN_DIR/mklml/
+
+echo "Fetching libtorch and dependencies..."
 
 # Detect OS via https://stackoverflow.com/a/8597411
 # URLs are from https://pytorch.org/get-started/locally/
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  MKLML_URL=https://github.com/intel/mkl-dnn/releases/download/v0.18/mklml_lnx_2019.0.3.20190220.tgz
   # Detect whether CUDA is installed
   if [[ -z $CUDA_ROOT ]] && [[ -d "$CUDA_ROOT" ]]; then
     if [[ "$CUDA_VERSION" == "10"* ]]; then
@@ -19,9 +28,11 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   # Mac OSX doesn't support CUDA anymore
   LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-macos-latest.zip
+  MKLML_URL=https://github.com/intel/mkl-dnn/releases/download/v0.18/mklml_mac_2019.0.3.20190220.tgz
 elif [[ "$OSTYPE" == "cygwin" ]]; then
   # TODO
   # POSIX compatibility layer and Linux environment emulation for Windows
+  MKLML_URL=https://github.com/intel/mkl-dnn/releases/download/v0.18/mklml_win_2019.0.3.20190220.tgz
   LIBTORCH_URL=""
 elif [[ "$OSTYPE" == "msys" ]]; then
   # Lightweight shell and GNU utilities compiled for Windows (part of MinGW)
@@ -36,14 +47,30 @@ else
   echo "Unknown platform. Need to build LibTorch from source."
 fi
 
-if [ ! -d "${LIBTORCH_DIR}" ]; then
-  echo "Downloading libtorch to ${LIBTORCH_DIR}..."
+# Install libtorch
+if [ ! -d "${LIBTORCH_DIR}/lib" ]; then
+  echo "Downloading libtorch from ${LIBTORCH_URL} to ${LIBTORCH_DIR}..."
   mkdir -p ${LIBTORCH_DIR}
 
-  curl -o libtorch.zip ${LIBTORCH_URL}
+  curl -L -o libtorch.zip ${LIBTORCH_URL}
   echo "Extracting libtorch to ${LIBTORCH_DIR}..."
   unzip -q libtorch.zip -d ${EXTERN_DIR}
+  echo "Removing zip file."
   rm -f libtorch.zip
 else
   echo "libtorch already installed in ${LIBTORCH_DIR}"
+fi
+
+# Install mklml
+if [ ! -d "${MKLML_DIR}/lib" ]; then
+  echo "Downloading MKLML from ${MKLML_URL} to ${MKLML_DIR}..."
+  mkdir -p ${MKLML_DIR}
+
+  curl -L -o mklml.tgz ${MKLML_URL}
+  echo "Extracting MKLML to ${MKLML_DIR}..."
+  tar -zxvf mklml.tgz --strip-components=1 -C ${MKLML_DIR}
+  echo "Removing zip file."
+  #rm -f mklml.tgz
+else
+  echo "MKLML already installed in ${MKLML_DIR}"
 fi


### PR DESCRIPTION
I'm interested in feedback on this idea & implementation:

Instead of requiring people to search online and install **libtorch** and **mklml** into this module's folder, download them automatically on installation.

This is with an eye towards an easy "npm install" / "yarn install" leading to a working implementation you can import within a larger node project.

### Issues:
- Something about the way that node / yarn runs the fetch dependencies script makes the `$OSTYPE` environment variable not visible anymore. So I see two ways forward:
  - Rewrite script in js w/ libraries that are designed to determine OS type
  - Attempt other hacky way in shell to determine OS type?
- Haven't tested CUDA support, `$CUDA_ROOT` env var may be missing anyway
- No fallback to compile libtorch/mklml from source